### PR TITLE
Add an h1 element to get rid of a WAVE warning

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -14,25 +14,26 @@
     <div class="nav-container">
       <div class="date-container">
         <div><span id="dateTime"></span></div>
-        <a>01/05/2020</a>
+        <a class="date">01/05/2020</a>
       </div>
         <button class="trips-button">Your Trips</button>
         <button class="expense-button">Your Expenses</button>
         <button class="book-trip-button">Book a New Trip</button>
-        <button>Logout</button>
+        <button class="logout-button">Logout</button>
     </div>
   </nav>
   <main>
-    <section class="trips-view">
-      <h2>Upcoming Trips</h2>
+    <section class="trips-view hidden">
+      <h1>Your Trips</h1>
+      <h2>Upcoming</h2>
       <div class="grid-container">
         <section class="future-trips-grid trips-grid"></section>
       </div>
-      <h2>Pending Trips</h2>
+      <h2>Pending</h2>
       <div class="grid-container">
         <section class="pending-trips-grid trips-grid"></section>
       </div>
-      <h2>Past Trips</h2>
+      <h2>Past</h2>
       <div class="grid-container">
         <section class="past-trips-grid trips-grid"></section>
       </div>
@@ -46,16 +47,18 @@
         </div>
         <p class="expense-message">*Price includes a 10% travel agent fee</p>
         <table class="expense-table">
+          <caption class="hidden">Your Expenses</caption>
           <tr>
             <th>Location</th>
             <th>Date</th>
             <th>Number of Days</th>
+            <th>Status</th>
             <th>Price*</th>
           </tr>
         </table>
       </div>
     </section>
-    <section class="booking-view hidden">
+    <section class="booking-view">
       <div class="form-container">
           <form class="form">
             <h2 class="request-to-book-text">Request to Book a Trip</h2>
@@ -134,7 +137,7 @@
             </div>
             <p class="empty-input-message hidden">Please fill out all fields</p>
           </form>
-          <h2 class="post-response-message hidden"></h2>
+          <h2 class="post-response-message hidden">Status of Post Request</h2>
       </div>
     </section>
   </main>

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -52,8 +52,10 @@ nav {
   font-size: 2vh;
 }
 
-#dateTime {
+#dateTime,
+.date {
   padding-right: 1vw;
+  font-size: 1.2vw;
 }
 
 button {
@@ -108,8 +110,14 @@ h2,
   padding: 1vh;
 }
 
+h1 {
+  font-size: 2vw;
+  margin-top: -2vw;
+}
+
 .no-trips-in-grid,
-h2 {
+h2,
+h1 {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -120,7 +128,7 @@ h2 {
 }
 
 .expense-message {
-  font-size: 1.5vh;
+  font-size: 1vw;
 }
 
 .expense-text-container,
@@ -128,6 +136,7 @@ h2 {
   display: flex;
   justify-content: center;
   align-items: center;
+  margin-top: -1vw;
 }
 
 .total-spent-text {
@@ -139,6 +148,7 @@ h2 {
   border-collapse: collapse;
   display: flex;
   justify-content: center;
+  padding-bottom: 2vw;
 }
 
 th {

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -167,7 +167,7 @@ function createTripsGrid(tripGrid, tripTimeline) {
 				tripGrid.innerHTML += ` <div class="trip-container">
                     <div class="trip-image-container">
                             <img class="trip-image"
-                            src=${destination.image}>
+                            src=${destination.image} alt="A picturesque view in ${destination.destination}">
                         </div>
                         <p>${destination.destination}</p>
                         <p>Duration: ${trip.duration} days</p>
@@ -201,11 +201,13 @@ function createExpenseTable() {
 				let cell2 = row.insertCell(1);
 				let cell3 = row.insertCell(2);
 				let cell4 = row.insertCell(3);
+                let cell5 = row.insertCell(4)
 
 				cell1.innerHTML = `${destination.destination}`;
 				cell2.innerHTML = `${trip.date}`;
 				cell3.innerHTML = `${trip.duration}`;
-				cell4.innerHTML = `$${destinations
+                cell4.innerHTML = `${trip.status}`;
+				cell5.innerHTML = `$${destinations
 					.findTripCost(trip)
 					.toLocaleString("en-US")}`;
                     tripsAlreadyInTable.push(trip)


### PR DESCRIPTION
## Scope
- I ran the WAVE web accessibility evaluation tool and Google's Lighthouse automated accessibility audit on my website and made the recommended changes to improve the accessibility of my website.

## Implementation
- WAVE recommended I add an h1 element to my page, give all my images alt text, and increase the font-size in my expenses section. I received a 100% score when I ran the Lighthouse accessibility audit on each page, so I did not make any additional changes.

## Reviewers
- Please run both evaluations and see if there are any errors or warnings.
